### PR TITLE
Small quality-of-life fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /pkg/
+wasify-*.gem

--- a/lib/wasify.rb
+++ b/lib/wasify.rb
@@ -22,8 +22,8 @@ class Wasify
 
   def self.generate_html(entrypoint)
     entrypoint_txt = DepsManager.add_entrypoint(entrypoint)
-    TEMPLATE = 'wasify/template.erb'
-    html = ERB.new(File.read(File.join(__dir__, TEMPLATE))).result(binding)
+    template = 'wasify/template.erb'
+    html = ERB.new(File.read(File.join(__dir__, template))).result(binding)
     File.rename('index.html', 'index.html.bak') if File.exist?('index.html')
     File.open('index.html', 'w+') do |f|
       f.write html

--- a/lib/wasify/cmd_runner.rb
+++ b/lib/wasify/cmd_runner.rb
@@ -9,6 +9,7 @@ class Wasify
 
     def self.unzip_binary
       system('tar xfz ruby-3_2-wasm32-unknown-wasi-full-js.tar.gz')
+      system('chmod u+rw 3_2-wasm32-unknown-wasi-full-js')
     end
 
     def self.move_binary

--- a/lib/wasify/deps_manager.rb
+++ b/lib/wasify/deps_manager.rb
@@ -4,23 +4,19 @@ class Wasify
   # methods finding and copying dependecies
   class DepsManager
     def self.get_specs(deps)
+      bundler_specs = Bundler.load.specs
+      lf = bundler_specs.map(&:loaded_from)
+      lf.select! { |item| !item.include?("/bundler-") && !item.include?("/wasify-") }
+
       spec_paths = []
-      deps.each do |i|
-        spec_path_str = ''
-        spec_path = i.split('/', -1)
-        spec_path.each_with_index do |s, index|
-          spec_path_str += "/#{s}" if index < spec_path.length - 2
-        end
-        spec_path_str += "/specifications/#{i.split('/', -1)[-1]}.gemspec"
-        spec_path_str[0] = ''
+      lf.each do |spec_path_str|
         if File.exist?(spec_path_str)
           spec_paths.append(spec_path_str)
         else
-          puts "#{spec_path_str} doenst exists. Specify gem path or write skip to skip specfile."
-          path = $stdin.gets.chomp
-          until File.exist?(path) || (path == 'skip')
-            puts "#{path} doenst exists. Specify gem path or write skip to skip specfile."
+          loop do
+            puts "#{spec_path_str} doesn't exist. Specify gemspec path or write 'skip' to skip specfile."
             path = $stdin.gets.chomp
+            break if File.exist?(path) || (path == 'skip')
           end
           spec_paths.append(path) unless path == 'skip'
         end


### PR DESCRIPTION
Ignore built gems so they don't get checked into Git.

TEMPLATE should just be a local var, not a constant.

The archive was somehow winding up with files that weren't allowed to read, so getting copy errors.

Bundler has a loaded_from on gemspecs that's easier to locate than reconstructing the path -- especially if a gem's path might not match its name.