### PR TITLE
Add prepack; add support for optional src/ paths; update Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /pkg/
 wasify-*.gem
+**/.DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    gemfile_parser (0.1.0)
-      bundler
-      parser
-      thor
     json (2.6.3)
     parallel (1.23.0)
     parser (3.2.2.1)
@@ -32,14 +28,13 @@ GEM
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
-    thor (1.2.2)
     unicode-display_width (2.4.2)
 
 PLATFORMS
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
-  gemfile_parser
   rake (~> 13.0)
   rubocop (~> 1.21)
   wasify!

--- a/exe/wasify
+++ b/exe/wasify
@@ -5,5 +5,9 @@ require 'wasify'
 
 raise 'Wrong number of arguments! Usage: wasify entrypoint.rb' if ARGV.length != 1
 
-Wasify.pack
-Wasify.generate_html(ARGV[0])
+if ARGV[0] == 'prepack'
+  Wasify.prepack
+else
+  Wasify.pack
+  Wasify.generate_html(ARGV[0])
+end

--- a/lib/wasify.rb
+++ b/lib/wasify.rb
@@ -7,7 +7,7 @@ require_relative 'wasify/cmd_runner'
 require_relative 'wasify/deps_manager'
 # wrapper for Wasify
 class Wasify
-  def self.pack
+  def self.prepack
     CMDRunner.download_binary unless File.exist?('ruby-3_2-wasm32-unknown-wasi-full-js.tar.gz')
     CMDRunner.unzip_binary unless Dir.exist?('ruby-3_2-wasm32-unknown-wasi-full-js')
     CMDRunner.move_binary unless File.exist?('ruby.wasm')
@@ -16,8 +16,20 @@ class Wasify
     File.delete('packed_ruby.wasm') if File.exist?('packed_ruby.wasm')
     DepsManager.copy_deps
     DepsManager.copy_specs
+  end
+
+  def self.build_wasm
     CMDRunner.run_vfs
+  end
+
+  def self.cleanup
     CMDRunner.cleanup
+  end
+
+  def self.pack
+    prepack
+    build_wasm
+    cleanup
   end
 
   def self.generate_html(entrypoint)

--- a/lib/wasify/deps_manager.rb
+++ b/lib/wasify/deps_manager.rb
@@ -51,8 +51,10 @@ class Wasify
     end
 
     def self.add_entrypoint(entrypoint)
+      entrypoint = entrypoint[4..-1] if entrypoint.start_with?("src/") && !File.exist?("src/#{entrypoint}")
+
       raise 'Invalid entrypoint! Entrypoint must be a Ruby script' unless entrypoint.include?('.rb')
-      raise 'Entrypoint does not exsist! All scripts must be in the src folder.' unless File.exist?("src/#{entrypoint}")
+      raise 'Entrypoint does not exist! All scripts must be in the src folder.' unless File.exist?("src/#{entrypoint}")
 
       entrypoint = entrypoint.delete_suffix('.rb')
       <<-HTML


### PR DESCRIPTION
I'm doing a lot of debugging the created source directories. It's useful for me to have a "prepack" mode with everything set up except the entrypoint. So I added a command for that.

Gemfile.lock is slightly out of date; updated it.

Added support for src/blah.rb paths rather than only blah.rb -- this only happens if the file specified doesn't exist, so it should never change the behaviour of a non-error case. But this allows tab-completion when writing "wasify src/button_alert.rb" or similar.