### PR TITLE
Make sure specifications dir exists if we need it, and do the chmod recursively

### DIFF
--- a/lib/wasify/cmd_runner.rb
+++ b/lib/wasify/cmd_runner.rb
@@ -9,7 +9,7 @@ class Wasify
 
     def self.unzip_binary
       system('tar xfz ruby-3_2-wasm32-unknown-wasi-full-js.tar.gz')
-      system('chmod u+rw 3_2-wasm32-unknown-wasi-full-js')
+      system('chmod -R u+rw 3_2-wasm32-unknown-wasi-full-js')
     end
 
     def self.move_binary

--- a/lib/wasify/deps_manager.rb
+++ b/lib/wasify/deps_manager.rb
@@ -84,6 +84,7 @@ class Wasify
     def self.copy_specs
       deps = get_deps
       specs = get_specs(deps)
+      FileUtils.mkdir_p "./3_2-wasm32-unknown-wasi-full-js/usr/local/lib/ruby/gems/3.2.0/specifications/"
       specs.each do |name, contents|
         File.write("./3_2-wasm32-unknown-wasi-full-js/usr/local/lib/ruby/gems/3.2.0/specifications/#{name}", contents)
       end


### PR DESCRIPTION
Found a couple of minor problems while updating scarpe-wasm...

When I added the chmod to deal with file path problems in the archive, I didn't make it recursive and it needs to be. D'oh!

And in some cases the specifications directory might not exist, so we need to create it if we're going to copy into it.