### PR TITLE
Ruby-wasm changed their release filenames

### DIFF
--- a/lib/wasify.rb
+++ b/lib/wasify.rb
@@ -8,8 +8,8 @@ require_relative 'wasify/deps_manager'
 # wrapper for Wasify
 class Wasify
   def self.prepack
-    CMDRunner.download_binary unless File.exist?('ruby-3_2-wasm32-unknown-wasi-full-js.tar.gz')
-    CMDRunner.unzip_binary unless Dir.exist?('ruby-3_2-wasm32-unknown-wasi-full-js')
+    CMDRunner.download_binary unless File.exist?('ruby-3.2-wasm32-unknown-wasi-full-js.tar.gz')
+    CMDRunner.unzip_binary unless Dir.exist?('ruby-3.2-wasm32-unknown-wasi-full-js')
     CMDRunner.move_binary unless File.exist?('ruby.wasm')
     CMDRunner.fix_lockfile
     CMDRunner.copy_gemfile

--- a/lib/wasify/cmd_runner.rb
+++ b/lib/wasify/cmd_runner.rb
@@ -4,16 +4,16 @@ class Wasify
   # methods interacting with the command line
   class CMDRunner
     def self.download_binary
-      system('curl -LO https://github.com/ruby/ruby.wasm/releases/latest/download/ruby-3_2-wasm32-unknown-wasi-full-js.tar.gz')
+      system('curl -LO https://github.com/ruby/ruby.wasm/releases/latest/download/ruby-3.2-wasm32-unknown-wasi-full-js.tar.gz')
     end
 
     def self.unzip_binary
-      system('tar xfz ruby-3_2-wasm32-unknown-wasi-full-js.tar.gz')
-      system('chmod -R u+rw 3_2-wasm32-unknown-wasi-full-js')
+      system('tar xfz ruby-3.2-wasm32-unknown-wasi-full-js.tar.gz')
+      system('chmod -R u+rw 3.2-wasm32-unknown-wasi-full-js')
     end
 
     def self.move_binary
-      system('mv 3_2-wasm32-unknown-wasi-full-js/usr/local/bin/ruby ruby.wasm')
+      system('mv 3.2-wasm32-unknown-wasi-full-js/usr/local/bin/ruby ruby.wasm')
     end
 
     def self.copy_gemfile
@@ -25,12 +25,12 @@ class Wasify
     end
 
     def self.run_vfs
-      system('wasi-vfs pack ruby.wasm --mapdir /src::./src --mapdir /usr::./3_2-wasm32-unknown-wasi-full-js/usr --mapdir /deps::./deps -o packed_ruby.wasm')
+      system('wasi-vfs pack ruby.wasm --mapdir /src::./src --mapdir /usr::./3.2-wasm32-unknown-wasi-full-js/usr --mapdir /deps::./deps -o packed_ruby.wasm')
     end
 
     def self.cleanup
-      system('rm -rf 3_2-wasm32-unknown-wasi-full-js')
-      system('rm ruby-3_2-wasm32-unknown-wasi-full-js.tar.gz')
+      system('rm -rf 3.2-wasm32-unknown-wasi-full-js')
+      system('rm ruby-3.2-wasm32-unknown-wasi-full-js.tar.gz')
       system('rm ruby.wasm')
       system('rm -rf deps')
     end

--- a/lib/wasify/deps_manager.rb
+++ b/lib/wasify/deps_manager.rb
@@ -64,7 +64,7 @@ class Wasify
 
     def self.copy_deps
       get_deps.each do |gem_name, dep|
-        dest_dir = "./3_2-wasm32-unknown-wasi-full-js/usr/local/lib/ruby/gems/3.2.0/gems/#{gem_name}"
+        dest_dir = "./3.2-wasm32-unknown-wasi-full-js/usr/local/lib/ruby/gems/3.2.0/gems/#{gem_name}"
         if dep[:files] == :all
           FileUtils.cp_r dep[:root], dest_dir
         elsif dep[:files].respond_to?(:each)
@@ -84,9 +84,9 @@ class Wasify
     def self.copy_specs
       deps = get_deps
       specs = get_specs(deps)
-      FileUtils.mkdir_p "./3_2-wasm32-unknown-wasi-full-js/usr/local/lib/ruby/gems/3.2.0/specifications/"
+      FileUtils.mkdir_p "./3.2-wasm32-unknown-wasi-full-js/usr/local/lib/ruby/gems/3.2.0/specifications/"
       specs.each do |name, contents|
-        File.write("./3_2-wasm32-unknown-wasi-full-js/usr/local/lib/ruby/gems/3.2.0/specifications/#{name}", contents)
+        File.write("./3.2-wasm32-unknown-wasi-full-js/usr/local/lib/ruby/gems/3.2.0/specifications/#{name}", contents)
       end
     end
 


### PR DESCRIPTION
Now it's "3.2" instead of "3_2" everywhere. This is a simple find/replace, so not sure this is 100% correct. It works better with scarpe-wasm, by which I mean it lets me get to the *next* bug, which isn't with wasify :-)