### PR TITLE
Use release 2.3.0 or earlier since 2.4.0 changes filenames and behavior significantly

### DIFF
--- a/lib/wasify.rb
+++ b/lib/wasify.rb
@@ -34,6 +34,7 @@ class Wasify
 
   def self.generate_html(entrypoint)
     entrypoint_txt = DepsManager.add_entrypoint(entrypoint)
+    wasm_wasi_version = ENV["WASIFY_VERSION"] || "2.3.0"
     template = 'wasify/template.erb'
     html = ERB.new(File.read(File.join(__dir__, template))).result(binding)
     File.rename('index.html', 'index.html.bak') if File.exist?('index.html')

--- a/lib/wasify/cmd_runner.rb
+++ b/lib/wasify/cmd_runner.rb
@@ -4,7 +4,8 @@ class Wasify
   # methods interacting with the command line
   class CMDRunner
     def self.download_binary
-      system('curl -LO https://github.com/ruby/ruby.wasm/releases/latest/download/ruby-3_2-wasm32-unknown-wasi-full-js.tar.gz')
+      version = ENV["WASIFY_VERSION"] || "2.3.0"
+      system("curl -LO https://github.com/ruby/ruby.wasm/releases/download/#{version}/ruby-3_2-wasm32-unknown-wasi-full-js.tar.gz")
     end
 
     def self.unzip_binary

--- a/lib/wasify/template.erb
+++ b/lib/wasify/template.erb
@@ -1,6 +1,6 @@
 
       <html>
-      <script src="https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@latest/dist/browser.umd.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@<%= wasm_wasi_version || "latest" %>/dist/browser.umd.js"></script>
       <script>
         const { DefaultRubyVM } = window["ruby-wasm-wasi"];
         const main = async () => {


### PR DESCRIPTION
This is a much smaller change, and probably a good idea regardless. We can cache the file much more easily if we're using a known release. But 2.4.0 clearly changes some other significant things, like not (as far as I can tell) having a writable temp area. Locking to 2.3.0 fixes that.

I added a WASIFY_VERSION to set version 2.3.0 or earlier, defaulting to 2.3.0. It won't work for version 2.4.0 or later because of the change in filenames.

If you'd rather wasify always use latest, let me know and I can look at adding some kind of version config and scarpe-wasm can lock the version for itself without affecting wasify.